### PR TITLE
Problems parsing concatenated long arc and sweep flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,16 @@ function parse(path) {
 		}
 
 		while (true) {
+			/**
+			* long arc and sweep flags 
+			* are boolean and can be concatenated like so:
+			* 11 or 01
+			*/
+			if (type === 'a' && args.length < length[type]) {
+				let flagArr = args[3].toString().split("");
+				args = [args[0], args[1], args[2], +flagArr[0], +flagArr[1], args[4], args[5]];
+			}
+			
 			if (args.length == length[type]) {
 				args.unshift(command)
 				return data.push(args)

--- a/index.js
+++ b/index.js
@@ -34,10 +34,19 @@ var segment = /([astvzqmhlc])([^astvzqmhlc]*)/ig
 	path
 	.replaceAll(" 00", " 0 0")
 	.replaceAll(" 01", " 0 1")
-	.replaceAll(" 11", " 1 1")
 	.replace(segment, function(_, command, args){
 		var type = command.toLowerCase()
 		args = parseValues(args)
+
+		/**
+		* long arc and sweep flags 
+		* are boolean and can be concatenated like so:
+		* 11 or 01
+		*/
+	        if (type === 'a' && args.length < length[type]) {
+	        	let flagArr = args[3].toString().split("");
+	        	args = [args[0], args[1], args[2], +flagArr[0], +flagArr[1], args[4], args[5]];
+	        }
 
 		// overloaded moveTo
 		if (type == 'm' && args.length > 2) {

--- a/index.js
+++ b/index.js
@@ -24,9 +24,18 @@ var segment = /([astvzqmhlc])([^astvzqmhlc]*)/ig
  * @return {Array}
  */
 
-function parse(path) {
-	var data = []
-	path.replace(segment, function(_, command, args){
+	function parse(path) {
+		var data = []
+	/**
+	* long arc and sweep flags
+	* are boolean and can be concatenated like so:
+	* 00, 11 or 01
+	*/
+	path
+	.replaceAll(" 00", " 0 0")
+	.replaceAll(" 01", " 0 1")
+	.replaceAll(" 11", " 1 1")
+	.replace(segment, function(_, command, args){
 		var type = command.toLowerCase()
 		args = parseValues(args)
 
@@ -38,16 +47,6 @@ function parse(path) {
 		}
 
 		while (true) {
-			/**
-			* long arc and sweep flags 
-			* are boolean and can be concatenated like so:
-			* 11 or 01
-			*/
-			if (type === 'a' && args.length < length[type]) {
-				let flagArr = args[3].toString().split("");
-				args = [args[0], args[1], args[2], +flagArr[0], +flagArr[1], args[4], args[5]];
-			}
-			
 			if (args.length == length[type]) {
 				args.unshift(command)
 				return data.push(args)


### PR DESCRIPTION
Thanks for this great parser!  
I found an issue when arctos use concatenated longarc and sweep flags (4. and 5. values) like this:     

` a 5 4 20 11 -10 -10.1 z`  

(unfortunately) this notation is valid so you might add an additional check to split these values.  
One idea would be to prepend an additional regex to split these values like so:  

```

  path
    .replaceAll(" 00", " 0 0")
    .replaceAll(" 01", " 0 1")
    .replaceAll(" 11", " 1 1")
```

and add a check while looping the commands  

```
          /**
           * long arc and sweep flags 
           * are boolean and can be concatenated like so:
           * 11 or 01
           */
          if (type === 'a' && args.length < length[type]) {
              let flagArr = args[3].toString().split("");
              args = [args[0], args[1], args[2], +flagArr[0], +flagArr[1], args[4], args[5]];
          }
```

See also [codepen example](https://codepen.io/herrstrietzel/pen/RwvjaXG)


